### PR TITLE
Consistent Node.js usage for Alttra

### DIFF
--- a/src/assets/data.json
+++ b/src/assets/data.json
@@ -257,7 +257,7 @@
 		"lng": -104.589516,
 		"technology": [
 			"JavaScript",
-			"Node JS",
+			"Node.js",
 			"React",
 			"Redux",
 			"Express.js",
@@ -272,7 +272,6 @@
 			"MongoDB",
 			"Redis",
 			"Celery"
-
 		]
 	},
 	{


### PR DESCRIPTION
I noticed while browsing the page Alttra had a different format for Node.js resulting in it not show up when filtering by Node.js